### PR TITLE
Fix Kotlin version for Capacitor 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npx cap sync
 ```js
 ...
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.20'
     dependencies {
         ...
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
Capacitor 5 [migration guide](https://capacitorjs.com/docs/updating/5-0#update-kotlin-version) recommends Kotlin version 1.8.20. And, for some reason Kotlin v1.6.10 was not building my app on Capacitor 5. Updating to 1.8.20 seems to work.