### PR TITLE
fix: closing animation on iOS to be similar to modal closing animation

### DIFF
--- a/ios/Plugin/Extensions/UIViewController.swift
+++ b/ios/Plugin/Extensions/UIViewController.swift
@@ -30,7 +30,7 @@ extension UIViewController {
         let transition = CATransition()
         transition.duration = 0.5
         transition.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-        transition.type = CATransitionType.push
+        transition.type = CATransitionType.reveal
         if swipeDirection == "up" {
             transition.subtype = CATransitionSubtype.fromTop
         } else if swipeDirection == "down" {

--- a/ios/Plugin/OnePhoto/OneImageViewController.swift
+++ b/ios/Plugin/OnePhoto/OneImageViewController.swift
@@ -241,7 +241,7 @@ class OneImageViewController: UIViewController, UIScrollViewDelegate {
         NotificationCenter.default.post(name: .photoviewerExit,
                                         object: nil,
                                         userInfo: vId)
-        self.dismissWithTransition(swipeDirection: "no")
+        self.dismissWithTransition(swipeDirection: "down")
         //        self.dismiss(animated: true, completion: nil)
     }
 

--- a/ios/Plugin/PhotoSlider/SliderViewController.swift
+++ b/ios/Plugin/PhotoSlider/SliderViewController.swift
@@ -343,7 +343,7 @@ class SliderViewController: UIViewController {
                                             object: nil,
                                             userInfo: vId)
         }
-        self.dismissWithTransition(swipeDirection: "no")
+        self.dismissWithTransition(swipeDirection: "down")
     }
 
     // MARK: - shareButtonTapped


### PR DESCRIPTION
This PR fix the issue described here: https://github.com/capacitor-community/photoviewer/issues/72.
It does not add an option to configure the animation style in the PhotoViewer’s settings but makes the closing animation (when pressing the cross) similar to the modal closing animation on iOS.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
